### PR TITLE
fix: correct duplicate entry for tailwind-merge and tailwindcss-animate in package.json and added expected comma

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,7 @@
     "recharts": "^3.2.1",
     "shadcn-ui": "^0.9.4",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^3.0.2",
-    "tailwindcss-animate": "^1.0.7",
-    "uuid": "^13.0.0"
+    "uuid": "^13.0.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7"
   },


### PR DESCRIPTION
This was an issue I ran into when I was about to start working on #51, the package.json was broken and had duplicte entries. I just pushed a little update to fix it.