### PR TITLE
feature: mobile navigation indicator

### DIFF
--- a/src/components/navigation/MobileMenu.tsx
+++ b/src/components/navigation/MobileMenu.tsx
@@ -9,9 +9,11 @@ interface MobileMenuProps {
   isOpen: boolean;
   onClose: () => void;
   isTablet?: boolean;
+  activeSection: string;
+  setActiveSection: (section: string) => void;
 }
 
-const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose, isTablet = false }) => {
+const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose, activeSection, setActiveSection, isTablet = false }) => {
   const [screenSize, setScreenSize] = useState<'mobile' | 'tablet' | 'laptop' | 'desktop'>('mobile');
   const [isClient, setIsClient] = useState(false);
 
@@ -56,6 +58,11 @@ const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose, isTablet = fal
       document.body.style.overflow = 'unset';
     };
   }, [isOpen, onClose]);
+
+  const handleOnClick = (section: string) => {
+    setActiveSection(section);
+    onClose();
+  };
 
   const menuVariants = {
     closed: {
@@ -188,8 +195,9 @@ const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose, isTablet = fal
                     >
                       <NavigationLink
                         href={item.href}
-                        onClick={onClose}
+                        onClick={() => handleOnClick(item.href)}
                         isMobile={true}
+                        activeSection={activeSection === item.href}
                       >
                         {item.label}
                       </NavigationLink>

--- a/src/components/navigation/Navbar.tsx
+++ b/src/components/navigation/Navbar.tsx
@@ -6,12 +6,23 @@ import { Button } from '@/components/ui/button';
 import HamburgerButton from '@/components/ui/hamburger-button';
 import MobileMenu from './MobileMenu';
 import NavigationLink from './NavigationLink';
+import { useActiveSection } from '@/hooks/use-active-section';
 import { ThemeToggle } from '../theme-toggle';
+
+const navigationItems = [
+  { href: "#features", label: "Features" },
+  { href: "#how-it-works", label: "How It Works" },
+  { href: "#pricing", label: "Pricing" },
+  { href: "#support", label: "Support" },
+];
 
 const Navbar: React.FC = () => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [screenSize, setScreenSize] = useState<'mobile' | 'tablet' | 'laptop' | 'desktop'>('laptop');
   const [isClient, setIsClient] = useState(false);
+  const { activeSection, setActiveSection } = useActiveSection(
+    navigationItems[0].href
+  );
 
   const toggleMobileMenu = () => {
     setIsMobileMenuOpen(!isMobileMenuOpen);
@@ -43,17 +54,8 @@ const Navbar: React.FC = () => {
     return () => window.removeEventListener('resize', checkScreenSize);
   }, []);
 
-  const navigationItems = [
-    { href: '#features', label: 'Features' },
-    { href: '#how-it-works', label: 'How It Works' },
-    { href: '#pricing', label: 'Pricing' },
-    { href: '/dashboard', label: 'Dashboard' },
-    { href: '#support', label: 'Support' }
-  ];
-
   return (
     <>
-      <nav className="w-full flex items-center justify-between px-4 py-4 relative z-10 laptop:container laptop:mx-auto bg-[#0a0a15]/80 backdrop-blur-sm border-b border-blue-800/20">
       <nav className="w-full flex items-center justify-between px-4 py-4 relative z-10 laptop:container laptop:mx-auto bg-background/80 backdrop-blur-md border-b border-border/50 transition-colors duration-300">
         {/* Logo */}
         <motion.div 
@@ -76,6 +78,7 @@ const Navbar: React.FC = () => {
             <NavigationLink
               key={item.href}
               href={item.href}
+              onClick={() => setActiveSection(item.href)}
               className="text-foreground/80 hover:text-blue-400 dark:hover:text-blue-300 transition-colors duration-300"
             >
               {item.label}
@@ -133,6 +136,8 @@ const Navbar: React.FC = () => {
           isOpen={isMobileMenuOpen}
           onClose={closeMobileMenu}
           isTablet={screenSize === 'tablet'}
+          activeSection={activeSection}
+          setActiveSection={setActiveSection}
         />
       )}
     </>

--- a/src/components/navigation/NavigationLink.tsx
+++ b/src/components/navigation/NavigationLink.tsx
@@ -10,6 +10,7 @@ interface NavigationLinkProps {
   onClick?: () => void;
   className?: string;
   isMobile?: boolean;
+  activeSection?: boolean;
 }
 
 const NavigationLink: React.FC<NavigationLinkProps> = ({ 
@@ -17,11 +18,16 @@ const NavigationLink: React.FC<NavigationLinkProps> = ({
   children, 
   onClick,
   className = "",
-  isMobile = false
+  isMobile = false,
+  activeSection = false
 }) => {
   const baseClasses = isMobile 
     ? "block px-4 py-3 text-lg font-medium text-foreground/80 dark:text-foreground/80 hover:text-foreground dark:hover:text-foreground hover:bg-blue-600/10 dark:hover:bg-blue-400/10 focus:outline-none focus:bg-blue-600/10 dark:focus:bg-blue-400/10 focus:text-foreground dark:focus:text-foreground focus:border-b-2 focus:border-blue-400 dark:focus:border-blue-300 transition-all duration-300 rounded-md mx-2"
     : "text-foreground/80 dark:text-foreground/80 hover:text-blue-400 dark:hover:text-blue-300 focus:outline-none focus:text-blue-400 dark:focus:text-blue-300 focus:border-b-2 focus:border-blue-400 dark:focus:border-blue-300 transition-all duration-300 px-2 py-1 relative";
+
+  const activeClasses = !isMobile
+    ? ""
+    : "text-blue-400 dark:text-blue-300 font-semibold relative after:content-[''] after:absolute after:left-0 after:right-0 after:-bottom-1 after:h-0.5 after:bg-blue-400 dark:after:bg-blue-300";
 
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
@@ -49,7 +55,7 @@ const NavigationLink: React.FC<NavigationLinkProps> = ({
       <Link 
         href={href}
         onClick={handleClick}
-        className={`${baseClasses} ${className}`}
+        className={`${baseClasses} ${className} ${activeSection ? activeClasses : ""}`}
       >
         {children}
         {/* Hover underline effect for desktop links */}

--- a/src/hooks/use-active-section.ts
+++ b/src/hooks/use-active-section.ts
@@ -1,0 +1,7 @@
+import { useState } from "react";
+
+// Hook that only stores and updates the active section
+export function useActiveSection(defaultSection: string) {
+    const [activeSection, setActiveSection] = useState(defaultSection);
+    return { activeSection, setActiveSection };
+}


### PR DESCRIPTION
# Pull Request for SafeTrust - Close Issue

❗ **Pull Request Information**

Adds an indicator to the current selected section on the mobile menu.

## 🌀 Summary of Changes

- New hooks `use-active-section.ts` to manage the current section.
- Updated the onClick handlers for links in both the navbar header and the mobile menu to update the active section.
- The currently active section is now underlined in the mobile menu.

## Screenshot
<img width="373" height="789" alt="image" src="https://github.com/user-attachments/assets/2eb58d20-9306-4010-8f5f-1883adc4da00" />

## 📂 Related Issue

This pull request will **close: #76** upon merging.

---

### Make sure to follow the Git Guidelines for Atomic Commits and read Contributing Guide

The Pull request needs to have the format mentioned below in the Git Guideline

- [Contributing Guide ](https://github.com/safetrustcr/Frontend/issues/34)
- [Git Guidelines](https://github.com/safetrustcr/Frontend/issues/35)

🎉 Thank you for reviewing this PR! 🎉
