### PR TITLE
feat: adding focus indicators to interactive elements

### DIFF
--- a/public/styles/globals.css
+++ b/public/styles/globals.css
@@ -237,3 +237,28 @@ body {
   }
 }
 
+.focus-visible {
+  @apply ring-2 ring-primary ring-offset-2 ring-offset-background outline-none;
+}
+
+/* Ensure links get focus outlines */
+a:focus-visible {
+  @apply focus-visible;
+}
+
+/* Ensure inputs get focus outlines */
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible {
+  @apply focus-visible;
+}
+
+/* Skip-to-content link (hidden until focused) */
+.skip-to-content {
+  @apply absolute left-2 top-2 -translate-y-full bg-primary text-primary-foreground px-3 py-2 rounded z-50;
+  transition: transform 0.2s ease;
+}
+
+.skip-to-content:focus {
+  @apply translate-y-0;
+}

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -230,10 +230,18 @@ export default function HeroSection() {
   };
 
   return (
-    <div className="min-h-screen bg-[#0a0a15] text-white overflow-hidden">
+    <div className="min-h-screen bg-[#0a0a15] text-white overflow-hidden relative">
+      {/* Skip to content link */}
+      <a href="#main-content" className="skip-to-content">
+        Skip to main content
+      </a>
+
       <Navbar />
 
-      <main className="container mx-auto min-h-[calc(100vh-80px)] grid grid-cols-1 lg:grid-cols-2 gap-12 px-4">
+      <main
+        id="main-content"
+        className="container mx-auto min-h-[calc(100vh-80px)] grid grid-cols-1 lg:grid-cols-2 gap-12 px-4"
+      >
         <div className="flex flex-col justify-center space-y-6">
           <motion.h1
             className="text-5xl font-bold leading-tight"
@@ -265,24 +273,27 @@ export default function HeroSection() {
           </motion.p>
 
           <motion.div
-  className="flex max-w-md items-center"
-  initial={{ opacity: 0, y: 20 }}
-  animate={{ opacity: 1, y: 0 }}
-  transition={{ duration: 0.5, delay: 0.9 }}
->
-  <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
-    <Button
-      className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 text-lg flex items-center gap-2"
-      onClick={() =>
-        buttonClick("connect_wallet_button", { location: "hero_section" })
-      }
-    >
-      <Wallet className="w-5 h-5" />
-      Connect Wallet
-    </Button>
-  </motion.div>
-</motion.div>
+            className="flex max-w-md items-center"
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.9 }}
+          >
+            <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+              <Button
+                className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 text-lg flex items-center gap-2 focus-visible"
+                onClick={() =>
+                  buttonClick("connect_wallet_button", {
+                    location: "hero_section",
+                  })
+                }
+              >
+                <Wallet className="w-5 h-5" />
+                Connect Wallet
+              </Button>
+            </motion.div>
+          </motion.div>
         </div>
+
 
         <motion.div
           className="hidden lg:flex items-center justify-center relative"

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 btn-animate",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 btn-animate",
   {
     variants: {
       variant: {
@@ -33,6 +33,7 @@ const buttonVariants = cva(
     },
   }
 )
+
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,


### PR DESCRIPTION
# Pull Request for SafeTrust - Close Issue

❗ **Pull Request Information**

This PR improves **keyboard navigation accessibility** by ensuring all interactive elements have visible focus indicators and adding a skip-to-content link for better user experience. These updates directly address the accessibility issue by making buttons, links, and form inputs easier to navigate for keyboard users.

## 🌀 Summary of Changes

* **Added `focus-visible` utility** to `globals.css` for consistent focus styling.
* **Updated `button.tsx`** to include focus styles using the new utility.
* **Modified `HeroSection.tsx`**:

  * Added a `skip-to-content` link for keyboard users.
  * Ensured `Connect Wallet` button has a visible focus ring.
  * Added `id="main-content"` to the main section for skip-link target.
* Prepared for similar updates in navigation (`Navbar.tsx`) for link focus indicators.

## 🛠 Testing

### Evidence Before Solution

* **Problem**: Buttons and links lacked visible focus styles, making keyboard navigation unclear.
[Screencast from 2025-10-04 16-16-10.webm](https://github.com/user-attachments/assets/df4e0978-b2ee-4bfc-b6dd-ce0733248584)


### Evidence After Solution

* **Solution**: Buttons, links, and form inputs now show a clear focus ring.
* **Skip-to-content** link enables skipping the navigation menu.
[Screencast from 2025-10-04 16-14-29.webm](https://github.com/user-attachments/assets/5bba7cc1-dddd-4cb2-9831-517f4035a3f4)


## 📂 Related Issue

This pull request will **close #62** upon merging.

---

### Make sure to follow the Git Guidelines for Atomic Commits and read Contributing Guide

* [[Contributing Guide ](https://github.com/safetrustcr/Frontend/issues/34)](https://github.com/safetrustcr/Frontend/issues/34)
* [[Git Guidelines](https://github.com/safetrustcr/Frontend/issues/35)](https://github.com/safetrustcr/Frontend/issues/35)

🎉 Thank you for reviewing this PR! 🎉