### PR TITLE
fix: suppress hydration warning in FooterSection logo wrapper

### DIFF
--- a/src/components/FooterSection.tsx
+++ b/src/components/FooterSection.tsx
@@ -17,7 +17,7 @@ export function Footer() {
       <div className="container mx-auto px-6 sm:px-8 lg:px-12 relative z-10">
         {/* Header area with logo and newsletter */}
         <div className="flex flex-col md:flex-row justify-between items-center mb-16">
-          <div className="flex items-center mb-6 md:mb-0">
+          <div className="flex items-center mb-6 md:mb-0" suppressHydrationWarning>
             <Image
               src="/landing-logo.jpeg"
               alt="SafeTrust"


### PR DESCRIPTION
## Problem

A React hydration error occurred in `FooterSection.tsx` caused by the Phantom wallet browser extension (`egjidjbpglichdcondbcbdnbeeppgdph`) injecting a `<div>` into the DOM before React hydrates. This created a mismatch between the server-rendered HTML and the client tree.

**Error:**
```
Hydration failed because the server rendered HTML didn't match the client.
src/components/FooterSection.tsx (20:26) @ Footer
```

Although recoverable, this caused unnecessary client-side re-renders of the entire footer tree on every page load for users with Phantom installed.

## Fix

Added `suppressHydrationWarning` to the logo wrapper `<div>` at line 20 of `FooterSection.tsx`:

```tsx
// Before
<div className="flex items-center mb-6 md:mb-0">

// After
<div className="flex items-center mb-6 md:mb-0" suppressHydrationWarning>
```

This is the React-recommended approach for handling third-party browser extension DOM injection. It scopes the warning suppression to only the affected node without impacting the rest of the component tree.

## Test Plan

- [x] Run `npm run dev` and open the landing page with Phantom wallet installed
- [x] Open DevTools Console and verify no `Hydration failed` error appears
- [x] Confirm footer renders correctly with and without the extension

## Notes

- No visual or functional changes — purely a hydration fix
- Does not affect users without Phantom installed

# Close #141 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a hydration behavior issue affecting the header logo element.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->