### PR TITLE
feat: implement FinalCTA Astro component

### DIFF
--- a/ST-Landing-Page(new one)/src/components/FinalCTA.astro
+++ b/ST-Landing-Page(new one)/src/components/FinalCTA.astro
@@ -1,0 +1,227 @@
+---
+---
+<section class="final-cta-section">
+  <div class="cta-bg-gradient"></div>
+  <div class="cta-bg-overlay"></div>
+  
+  <div class="cta-content">
+    <div class="eyebrow-container">
+      <span class="eyebrow-pill">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"/><path d="M5 3v4"/><path d="M19 17v4"/><path d="M3 5h4"/><path d="M17 19h4"/></svg>
+        Start Your Journey
+      </span>
+    </div>
+
+    <h2 class="cta-heading">
+      Ready to secure your<br/>
+      <span class="italic text-purple-accent">with transactions?</span>
+    </h2>
+
+    <p class="cta-description">
+      Join thousands of users who trust SafeTrust for secure, transparent, and decentralized transactions. Get started in minutes.
+    </p>
+
+    <div class="cta-actions">
+      <button class="btn-primary">
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 7V4a1 1 0 0 0-1-1H5a2 2 0 0 0 0 4h15a1 1 0 0 1 1 1v4h-3a2 2 0 0 0 0 4h3a8 8 0 0 1-8 8H5a2 2 0 0 1-2-2V5"/><path d="M17 11.5v.5"/><path d="M17 15.5v-.5"/></svg>
+        Connect Wallet &rarr;
+      </button>
+      <button class="btn-secondary">
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
+        Read the Docs &rarr;
+      </button>
+    </div>
+
+    <div class="cta-stats">
+      <div class="stat-item">
+        <span class="dot dot-green"></span>
+        10,000+ Active Users
+      </div>
+      <div class="stat-divider"></div>
+      <div class="stat-item">
+        <span class="dot dot-blue"></span>
+        $50M+ Secured
+      </div>
+      <div class="stat-divider"></div>
+      <div class="stat-item">
+        <span class="dot dot-purple"></span>
+        99.9% Uptime
+      </div>
+    </div>
+  </div>
+</section>
+
+<style>
+  .final-cta-section {
+    position: relative;
+    padding: 5rem 1rem;
+    overflow: hidden;
+    text-align: center;
+  }
+  @media (min-width: 768px) {
+    .final-cta-section {
+      padding: 7rem 2rem;
+    }
+  }
+
+  .cta-bg-gradient {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(to bottom right, #111827, #1e3a8a, #000000);
+    z-index: 1;
+  }
+
+  .cta-bg-overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(to top, rgba(0,0,0,0.5), transparent);
+    z-index: 2;
+  }
+
+  .cta-content {
+    position: relative;
+    z-index: 10;
+    max-width: 64rem;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .eyebrow-container {
+    margin-bottom: 1.5rem;
+  }
+
+  .eyebrow-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    background: rgba(59, 130, 246, 0.1);
+    border: 1px solid rgba(59, 130, 246, 0.2);
+    border-radius: 9999px;
+    color: #93c5fd;
+    font-weight: 600;
+    font-size: 0.875rem;
+  }
+
+  .cta-heading {
+    font-size: 2.25rem;
+    line-height: 1.2;
+    font-weight: 700;
+    color: white;
+    margin: 0 0 1.5rem 0;
+  }
+  @media (min-width: 768px) {
+    .cta-heading {
+      font-size: 3.75rem;
+    }
+  }
+
+  .text-purple-accent {
+    font-style: italic;
+    background: linear-gradient(to right, #a855f7, #ec4899);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+
+  .cta-description {
+    font-size: 1.125rem;
+    color: #d1d5db;
+    max-width: 42rem;
+    margin: 0 0 2.5rem 0;
+    line-height: 1.6;
+  }
+
+  .cta-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    width: 100%;
+    justify-content: center;
+  }
+  @media (min-width: 640px) {
+    .cta-actions {
+      flex-direction: row;
+      width: auto;
+    }
+  }
+
+  .btn-primary, .btn-secondary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 1rem 2rem;
+    border-radius: 0.75rem;
+    font-weight: 600;
+    font-size: 1.125rem;
+    cursor: pointer;
+    transition: all 0.3s ease;
+  }
+
+  .btn-primary {
+    background: linear-gradient(to right, #3b82f6, #2563eb);
+    color: white;
+    border: none;
+    box-shadow: 0 4px 14px 0 rgba(59, 130, 246, 0.39);
+  }
+  .btn-primary:hover {
+    transform: scale(1.02);
+  }
+
+  .btn-secondary {
+    background: transparent;
+    color: white;
+    border: 2px solid rgba(255, 255, 255, 0.2);
+  }
+  .btn-secondary:hover {
+    border-color: rgba(59, 130, 246, 0.5);
+    background: rgba(255, 255, 255, 0.05);
+    transform: scale(1.02);
+  }
+
+  .cta-stats {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 1.5rem;
+    margin-top: 3rem;
+    color: #9ca3af;
+    font-size: 0.875rem;
+  }
+
+  .stat-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .stat-divider {
+    display: none;
+    width: 1px;
+    height: 1rem;
+    background: #4b5563;
+  }
+  @media (min-width: 640px) {
+    .stat-divider {
+      display: block;
+    }
+  }
+
+  .dot {
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 50%;
+    animation: pulse 2s infinite;
+  }
+  .dot-green { background-color: #22c55e; }
+  .dot-blue { background-color: #3b82f6; }
+  .dot-purple { background-color: #a855f7; }
+
+  @keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.5; }
+  }
+</style>


### PR DESCRIPTION
Closes #198 

# Implement FinalCTA Astro Component

## Description
This PR addresses the missing `FinalCTA.astro` component in the new Astro landing page (`ST-Landing-Page`). It implements the final call-to-action section by migrating the dark gradient banner from the original Next.js landing page to a fully static Astro component.

### Changes Made
- Added a full-width dark gradient banner matching the deep navy/indigo original background.
- Included the `Start Your Journey` eyebrow pill.
- Implemented the headline with the exact requested text and an italic purple accent on the second line.
- Added the supporting paragraph.
- Designed two CTA buttons (`Connect Wallet →` in blue and `Read the Docs →` in outline style) using encapsulated CSS and SVGs.
- Built the inline stats row (10,000+ Active Users, $50M+ Secured, and 99.9% Uptime) with pulsing dot indicators.
- Replaced all React logic and Framer Motion dependencies with a pure HTML layout and a standard scoped `<style>` block.

## Type of Change
- [x] Feature Request

## Testing / Reproduction Steps
1. Checkout this branch: `git checkout feat/final-cta-astro`
2. Navigate to the project directory: `cd ST-Landing-Page(new one)` *(Please adjust to match actual directory path)*
3. Install dependencies and start the dev server: `npm install && npm run dev`
4. Open `http://localhost:4321/` in your browser.
5. Scroll to the bottom of the page content to observe the fully rendered final CTA banner just above the footer.
