### PR TITLE
fix: connect Wallet button returns 404

### DIFF
--- a/ST-Landing-Page(new one)/src/components/Hero/CTAButtons.astro
+++ b/ST-Landing-Page(new one)/src/components/Hero/CTAButtons.astro
@@ -1,5 +1,5 @@
 <div class="cta-buttons">
-  <a href="/register" class="btn-primary">
+  <a href="#our-promise" class="btn-primary">
     Get Started
     <span class="arrow">→</span>
   </a>

--- a/ST-Landing-Page(new one)/src/components/HowItWorks/HowItWorksSection.astro
+++ b/ST-Landing-Page(new one)/src/components/HowItWorks/HowItWorksSection.astro
@@ -56,7 +56,7 @@ const STATUS_CONFIG = {
 
   <div class="cta">
     <p>Ready to secure your transactions?</p>
-    <a href="/register" class="cta-btn">Get Started →</a>
+    <a href="#our-promise" class="cta-btn">Get Started →</a>
   </div>
 </section>
 

--- a/ST-Landing-Page(new one)/src/components/Navbar.astro
+++ b/ST-Landing-Page(new one)/src/components/Navbar.astro
@@ -18,7 +18,7 @@ const navLinks = [
     ))}
   </div>
 
-  <a href="/register" class="navbar-cta">Connect Wallet</a>
+  <a href="#our-promise" class="navbar-cta">Connect Wallet</a>
 </nav>
 
 <style>

--- a/ST-Landing-Page(new one)/src/components/OurPromise.astro
+++ b/ST-Landing-Page(new one)/src/components/OurPromise.astro
@@ -8,7 +8,7 @@ const guarantees = [
 ];
 ---
 
-<section class="our-promise">
+<section id="our-promise" class="our-promise">
   <div class="promise-grid">
     <div class="promise-text">
       <p class="eyebrow">— Our promise</p>


### PR DESCRIPTION
Closes #204 

###Fix
Replaced the broken `/register` landing-page CTAs with in-page navigation to `#our-promise`, and added the anchor target to the Promise section. This removes the 404 on the Navbar “Connect Wallet” button and keeps the existing hero/how-it-works CTAs aligned with the same interim flow until wallet integration is wired in.

###Validation
Confirmed there are no remaining `/register` links in the landing-page source and the edited Astro files parse cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated key call-to-action links to jump directly to the “Our Promise” section on the page.
  * Added a direct anchor target for that section, making it easier for visitors to navigate from multiple entry points.

* **Bug Fixes**
  * Improved CTA destination consistency across the landing page so buttons now lead to the same in-page section instead of a separate route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->