### PR TITLE
feat: redesign our promise section with dynamic astro styling

### DIFF
--- a/ST-Landing-Page(new one)/astro.config.mjs
+++ b/ST-Landing-Page(new one)/astro.config.mjs
@@ -21,6 +21,7 @@ export default defineConfig({
           "globe",
           "clock",
           "scale",
+          "users",
           "wallet",
           "shield-check",
           "coins",

--- a/ST-Landing-Page(new one)/package-lock.json
+++ b/ST-Landing-Page(new one)/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/react": "^5.0.7",
         "@iconify-json/lucide": "^1.2.111",
+        "@stellar/freighter-api": "^6.0.1",
         "astro": "^5.7.0",
         "astro-icon": "^1.1.5",
         "lucide-react": "^1.17.0",
@@ -2138,6 +2139,28 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@stellar/freighter-api": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@stellar/freighter-api/-/freighter-api-6.0.1.tgz",
+      "integrity": "sha512-eqwakEqSg+zoLuPpSbKyrX0pG8DQFzL/J5GtbfuMCmJI+h+oiC9pQ5C6QLc80xopZQKdGt8dUAFCmDMNdAG95w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "buffer": "6.0.3",
+        "semver": "7.7.1"
+      }
+    },
+    "node_modules/@stellar/freighter-api/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2557,6 +2580,26 @@
       "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.32",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
@@ -2628,6 +2671,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-crc32": {
@@ -3697,6 +3764,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/import-meta-resolve": {
       "version": "4.2.0",

--- a/ST-Landing-Page(new one)/package.json
+++ b/ST-Landing-Page(new one)/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@astrojs/react": "^5.0.7",
     "@iconify-json/lucide": "^1.2.111",
+    "@stellar/freighter-api": "^6.0.1",
     "astro": "^5.7.0",
     "astro-icon": "^1.1.5",
     "lucide-react": "^1.17.0",

--- a/ST-Landing-Page(new one)/src/components/ConnectWalletCTA.tsx
+++ b/ST-Landing-Page(new one)/src/components/ConnectWalletCTA.tsx
@@ -1,3 +1,4 @@
+import { ArrowRight, CheckCircle2, Lock } from "lucide-react";
 import { useState } from "react";
 
 export default function ConnectWalletCTA() {
@@ -6,7 +7,7 @@ export default function ConnectWalletCTA() {
   const handleClick = async () => {
     if (state !== "idle") return;
     setState("connecting");
-    // TODO: wire up Freighter wallet connection
+    // TODO: wire up Freighter wallet connection.
     setState("connected");
   };
 
@@ -16,12 +17,34 @@ export default function ConnectWalletCTA() {
     connected: "Wallet Connected",
   }[state];
 
+  const LeadingIcon = state === "connected" ? CheckCircle2 : Lock;
+
   return (
-    <div className="cta-row">
-      <button onClick={handleClick} disabled={state === "connecting"} className={`connect-btn ${state}`}>
-        🔒 {label} →
+    <div className="connect-wallet-cta">
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={state === "connecting"}
+        className="connect-wallet-cta__action connect-wallet-cta__action--primary"
+      >
+        <span className="connect-wallet-cta__icon" aria-hidden="true">
+          <LeadingIcon size={17} strokeWidth={2.2} />
+        </span>
+        <span>{label}</span>
+        <span className="connect-wallet-cta__icon" aria-hidden="true">
+          <ArrowRight size={16} strokeWidth={2.2} />
+        </span>
       </button>
-      <a href="#how-it-works" className="learn-more-btn">Learn More →</a>
+
+      <a
+        href="#how-it-works"
+        className="connect-wallet-cta__action connect-wallet-cta__action--secondary"
+      >
+        <span>Learn More</span>
+        <span className="connect-wallet-cta__icon" aria-hidden="true">
+          <ArrowRight size={16} strokeWidth={2.2} />
+        </span>
+      </a>
     </div>
   );
 }

--- a/ST-Landing-Page(new one)/src/components/ConnectWalletCTA.tsx
+++ b/ST-Landing-Page(new one)/src/components/ConnectWalletCTA.tsx
@@ -1,3 +1,4 @@
+import { isConnected, requestAccess } from "@stellar/freighter-api";
 import { ArrowRight, CheckCircle2, Lock } from "lucide-react";
 import { useState } from "react";
 
@@ -7,8 +8,21 @@ export default function ConnectWalletCTA() {
   const handleClick = async () => {
     if (state !== "idle") return;
     setState("connecting");
-    // TODO: wire up Freighter wallet connection.
-    setState("connected");
+    try {
+      const { isConnected: hasFreighter } = await isConnected();
+      if (!hasFreighter) {
+        setState("idle");
+        return;
+      }
+      const { address, error } = await requestAccess();
+      if (error || !address) {
+        setState("idle");
+        return;
+      }
+      setState("connected");
+    } catch {
+      setState("idle");
+    }
   };
 
   const label = {

--- a/ST-Landing-Page(new one)/src/components/OurPromise.astro
+++ b/ST-Landing-Page(new one)/src/components/OurPromise.astro
@@ -1,87 +1,553 @@
 ---
+import { Icon } from "astro-icon/components";
 import ConnectWalletCTA from "./ConnectWalletCTA.tsx";
 
 const guarantees = [
-  { title: "Funds held in smart contract", tag: "soroban", desc: "Not in our database. Not in a bank. In code." },
-  { title: "Released only on dual consent", tag: "2/2 sig", desc: "Both buyer and seller must confirm. No exceptions." },
-  { title: "Transparent arbitration", tag: "on-chain", desc: "Disputes resolved with verifiable evidence." },
+  {
+    title: "Funds held in smart contract",
+    tag: "soroban",
+    desc: "Deposits stay in on-chain escrow, not in a database or custodial account.",
+    icon: "lucide:shield-check",
+    tone: "primary",
+  },
+  {
+    title: "Released only on dual consent",
+    tag: "2/2 sig",
+    desc: "Buyer and seller both approve before any release can happen.",
+    icon: "lucide:users",
+    tone: "accent",
+  },
+  {
+    title: "Transparent arbitration",
+    tag: "on-chain",
+    desc: "Disputes follow verifiable evidence and rules anyone can inspect.",
+    icon: "lucide:scale",
+    tone: "emerald",
+  },
+];
+
+const miniBadges = [
+  { label: "Bank-grade security", icon: "lucide:shield-check", tone: "primary" },
+  { label: "End-to-end encrypted", icon: "lucide:lock", tone: "accent" },
+  { label: "USDT protected", icon: "lucide:coins", tone: "gold" },
 ];
 ---
 
-<section class="our-promise">
-  <div class="promise-grid">
-    <div class="promise-text">
-      <p class="eyebrow">— Our promise</p>
-      <h2>Secure, transparent, <em>trusted.</em></h2>
-      <p class="description">
-        Decentralized escrow that holds every deposit until both parties confirm —
-        no middlemen, no surprises — just code you can verify yourself.
+<section class="our-promise" id="our-promise">
+  <div class="our-promise__backdrop" aria-hidden="true">
+    <div class="our-promise__glow our-promise__glow--left"></div>
+    <div class="our-promise__glow our-promise__glow--right"></div>
+  </div>
+
+  <div class="our-promise__grid">
+    <div class="our-promise__content">
+      <p class="our-promise__eyebrow">Our promise</p>
+      <h2 class="our-promise__headline">
+        Secure, transparent, <em>trusted.</em>
+      </h2>
+      <p class="our-promise__description">
+        Decentralized escrow that holds every deposit until both parties confirm, with no
+        middlemen, no surprises, and code you can verify yourself.
       </p>
 
       <ConnectWalletCTA client:visible />
 
-      <div class="mini-badges">
-        <span>✓ Bank-grade security</span>
-        <span>🔒 End-to-end encrypted</span>
-        <span>⭐ USDT protected</span>
+      <div class="our-promise__badges" aria-label="Platform trust signals">
+        {miniBadges.map((badge) => (
+          <span class={`our-promise__badge our-promise__badge--${badge.tone}`}>
+            <span class="our-promise__badge-icon" aria-hidden="true">
+              <Icon name={badge.icon} width="15" height="15" />
+            </span>
+            {badge.label}
+          </span>
+        ))}
       </div>
     </div>
 
-    <div class="guarantees-card">
-      <span class="verified-badge">VERIFIED ON-CHAIN<br/><small>v2.4 mainnet</small></span>
-      <p class="guarantees-eyebrow">SAFETRUST GUARANTEES</p>
-      {guarantees.map((g) => (
-        <div class="guarantee-row">
-          <strong>{g.title}</strong> <span class="tag">{g.tag}</span>
-          <p>{g.desc}</p>
+    <div class="our-promise__card-shell">
+      <span class="our-promise__verified-badge">
+        <span class="our-promise__verified-label">Verified on-chain</span>
+        <span class="our-promise__verified-version">
+          <span class="our-promise__live-dot" aria-hidden="true"></span>
+          v2.4 mainnet
+        </span>
+      </span>
+
+      <div class="our-promise__card">
+        <p class="our-promise__card-eyebrow">SafeTrust guarantees</p>
+
+        <div class="our-promise__guarantees">
+          {guarantees.map((guarantee) => (
+            <div class="our-promise__guarantee">
+              <div class={`our-promise__guarantee-icon our-promise__guarantee-icon--${guarantee.tone}`}>
+                <Icon name={guarantee.icon} width="20" height="20" />
+              </div>
+
+              <div class="our-promise__guarantee-copy">
+                <div class="our-promise__guarantee-header">
+                  <strong>{guarantee.title}</strong>
+                  <span class="our-promise__tag">{guarantee.tag}</span>
+                </div>
+                <p>{guarantee.desc}</p>
+              </div>
+            </div>
+          ))}
         </div>
-      ))}
+      </div>
     </div>
   </div>
 </section>
 
 <style>
-  .our-promise { padding: 4rem 2rem; max-width: 1280px; margin: 0 auto; }
-  .promise-grid {
-    display: grid; gap: 2rem;
-    grid-template-columns: 1fr;
-  }
-  @media (min-width: 1024px) {
-    .promise-grid { grid-template-columns: 1fr 1fr; align-items: start; }
-  }
-  .eyebrow {
-    font-size: 0.75rem; font-weight: 700; letter-spacing: 0.2em;
-    text-transform: uppercase; color: #2857B8; margin-bottom: 0.75rem;
-  }
-  h2 { font-size: clamp(1.75rem, 4vw, 3rem); font-weight: 800; line-height: 1.15; }
-  h2 em { color: #7c3aed; font-style: italic; }
-  .description { margin-top: 1rem; color: var(--muted-foreground, #6b7280); max-width: 36rem; line-height: 1.6; }
-  .mini-badges { display: flex; gap: 1rem; margin-top: 1.5rem; font-size: 0.875rem; flex-wrap: wrap; }
-
-  .guarantees-card {
+  .our-promise {
     position: relative;
-    border: 1px solid var(--border, #e5e7eb);
-    border-radius: 1rem;
-    padding: 1.5rem;
-    box-shadow: 0 10px 30px -10px rgba(0,0,0,0.08);
+    isolation: isolate;
+    overflow: hidden;
+    padding: clamp(4.5rem, 8vw, 7rem) 1.5rem;
+    background: linear-gradient(135deg, rgba(40, 87, 184, 0.03), rgba(124, 58, 237, 0.03));
   }
-  .verified-badge {
-    position: absolute; top: -1rem; right: 1rem;
-    background: #1e1b4b; color: #fff;
-    font-size: 0.7rem; font-weight: 700;
-    padding: 0.5rem 0.75rem; border-radius: 0.5rem;
-    text-align: center;
+
+  .our-promise::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: -2;
+    background-image:
+      linear-gradient(rgba(15, 23, 42, 0.05) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(15, 23, 42, 0.05) 1px, transparent 1px);
+    background-size: 36px 36px;
+    mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.55), transparent 92%);
+    pointer-events: none;
   }
-  .guarantees-eyebrow {
-    font-size: 0.7rem; font-weight: 700; letter-spacing: 0.15em;
-    color: var(--muted-foreground, #9ca3af); margin-bottom: 1rem;
+
+  .our-promise__backdrop {
+    position: absolute;
+    inset: 0;
+    z-index: -3;
+    pointer-events: none;
   }
-  .guarantee-row { padding: 0.75rem 0; border-top: 1px solid var(--border, #f3f4f6); }
-  .guarantee-row:first-of-type { border-top: none; }
-  .tag {
-    font-size: 0.7rem; font-weight: 600;
-    background: #ede9fe; color: #6d28d9;
-    padding: 0.1rem 0.5rem; border-radius: 999px;
+
+  .our-promise__glow {
+    position: absolute;
+    border-radius: 999px;
+    filter: blur(80px);
+    opacity: 0.55;
   }
-  .guarantee-row p { font-size: 0.875rem; color: var(--muted-foreground, #6b7280); margin-top: 0.25rem; }
+
+  .our-promise__glow--left {
+    width: 18rem;
+    height: 18rem;
+    left: -4rem;
+    top: 2rem;
+    background: rgba(40, 87, 184, 0.16);
+  }
+
+  .our-promise__glow--right {
+    width: 20rem;
+    height: 20rem;
+    right: -6rem;
+    bottom: -3rem;
+    background: rgba(124, 58, 237, 0.14);
+  }
+
+  .our-promise__grid {
+    max-width: 1280px;
+    margin: 0 auto;
+    display: grid;
+    gap: clamp(2rem, 4vw, 4rem);
+    align-items: center;
+  }
+
+  @media (min-width: 1024px) {
+    .our-promise__grid {
+      grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+    }
+  }
+
+  .our-promise__content {
+    position: relative;
+  }
+
+  .our-promise__eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 0 0 1rem;
+    font-size: 0.75rem;
+    font-weight: 800;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    color: #2857b8;
+    opacity: 0;
+    transform: translateY(12px);
+    animation: eyebrowReveal 0.75s ease-out forwards;
+  }
+
+  .our-promise__eyebrow::before {
+    content: "";
+    width: 2.5rem;
+    height: 1px;
+    background: linear-gradient(90deg, rgba(40, 87, 184, 0.25), #2857b8);
+    transform-origin: left center;
+    animation: eyebrowLine 0.75s ease-out forwards;
+  }
+
+  @supports (animation-timeline: view()) {
+    .our-promise__eyebrow,
+    .our-promise__eyebrow::before {
+      animation-timeline: view(block 80% 10%);
+    }
+  }
+
+  .our-promise__headline {
+    margin: 0;
+    font-size: clamp(2.25rem, 5vw, 4rem);
+    font-weight: 800;
+    line-height: 1.05;
+    letter-spacing: -0.04em;
+    color: #0f172a;
+    text-wrap: balance;
+  }
+
+  .our-promise__headline em {
+    font-style: italic;
+    color: transparent;
+    background: linear-gradient(90deg, #6d28d9, #8b5cf6 55%, #2857b8);
+    -webkit-background-clip: text;
+    background-clip: text;
+  }
+
+  .our-promise__description {
+    max-width: 38rem;
+    margin: 1.5rem 0 0;
+    font-size: 1.0625rem;
+    line-height: 1.8;
+    color: #64748b;
+  }
+
+  .our-promise__badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.875rem;
+    margin-top: 1.75rem;
+  }
+
+  .our-promise__badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.7rem 1rem;
+    border: 1px solid rgba(40, 87, 184, 0.14);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.58);
+    box-shadow: 0 10px 24px -18px rgba(15, 23, 42, 0.4);
+    backdrop-filter: blur(10px);
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #1e293b;
+  }
+
+  .our-promise__badge-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.65rem;
+    height: 1.65rem;
+    border-radius: 999px;
+    flex-shrink: 0;
+  }
+
+  .our-promise__badge--primary .our-promise__badge-icon {
+    background: rgba(40, 87, 184, 0.14);
+    color: #2857b8;
+  }
+
+  .our-promise__badge--accent .our-promise__badge-icon {
+    background: rgba(124, 58, 237, 0.16);
+    color: #7c3aed;
+  }
+
+  .our-promise__badge--gold .our-promise__badge-icon {
+    background: rgba(245, 158, 11, 0.16);
+    color: #d97706;
+  }
+
+  .our-promise__card-shell {
+    position: relative;
+    padding-top: 1.5rem;
+  }
+
+  .our-promise__verified-badge {
+    position: absolute;
+    top: 0;
+    right: 1.25rem;
+    display: inline-flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.7rem 0.9rem;
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    border-radius: 0.9rem;
+    background: rgba(16, 25, 63, 0.95);
+    box-shadow: 0 18px 36px -20px rgba(16, 25, 63, 0.8);
+    color: #fff;
+    backdrop-filter: blur(16px);
+  }
+
+  .our-promise__verified-label {
+    font-size: 0.64rem;
+    font-weight: 800;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+  }
+
+  .our-promise__verified-version {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-size: 0.78rem;
+    color: #bfdbfe;
+  }
+
+  .our-promise__live-dot {
+    width: 0.55rem;
+    height: 0.55rem;
+    border-radius: 999px;
+    background: #22c55e;
+    box-shadow: 0 0 0 rgba(34, 197, 94, 0.55);
+    animation: pulseDot 1.8s ease-out infinite;
+  }
+
+  .our-promise__card {
+    position: relative;
+    overflow: hidden;
+    padding: 2rem 1.5rem 1.5rem;
+    border: 1px solid rgba(40, 87, 184, 0.15);
+    border-radius: 1.5rem;
+    background:
+      linear-gradient(180deg, rgba(255, 255, 255, 0.82), rgba(255, 255, 255, 0.7)),
+      radial-gradient(circle at top left, rgba(191, 219, 254, 0.28), transparent 42%);
+    box-shadow: 0 20px 40px -12px rgba(40, 87, 184, 0.12);
+    backdrop-filter: blur(16px);
+  }
+
+  .our-promise__card::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.18), transparent 42%);
+    pointer-events: none;
+  }
+
+  .our-promise__card-eyebrow {
+    margin: 0 0 1.25rem;
+    font-size: 0.72rem;
+    font-weight: 800;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: #64748b;
+  }
+
+  .our-promise__guarantees {
+    display: grid;
+    gap: 0.9rem;
+  }
+
+  .our-promise__guarantee {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 1rem;
+    align-items: start;
+    padding: 1rem 0;
+    border-top: 1px solid rgba(148, 163, 184, 0.18);
+  }
+
+  .our-promise__guarantee:first-child {
+    border-top: none;
+    padding-top: 0;
+  }
+
+  .our-promise__guarantee-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.8rem;
+    height: 2.8rem;
+    border-radius: 0.9rem;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55);
+  }
+
+  .our-promise__guarantee-icon--primary {
+    background: linear-gradient(135deg, rgba(40, 87, 184, 0.18), rgba(96, 165, 250, 0.24));
+    color: #2857b8;
+  }
+
+  .our-promise__guarantee-icon--accent {
+    background: linear-gradient(135deg, rgba(124, 58, 237, 0.18), rgba(167, 139, 250, 0.22));
+    color: #7c3aed;
+  }
+
+  .our-promise__guarantee-icon--emerald {
+    background: linear-gradient(135deg, rgba(22, 163, 74, 0.18), rgba(74, 222, 128, 0.2));
+    color: #15803d;
+  }
+
+  .our-promise__guarantee-copy strong {
+    font-size: 1rem;
+    color: #0f172a;
+  }
+
+  .our-promise__guarantee-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.55rem;
+    margin-bottom: 0.35rem;
+  }
+
+  .our-promise__tag {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.5rem;
+    padding: 0.1rem 0.6rem;
+    border: 1px solid rgba(124, 58, 237, 0.15);
+    border-radius: 999px;
+    background: rgba(124, 58, 237, 0.08);
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    color: #6d28d9;
+    text-transform: lowercase;
+  }
+
+  .our-promise__guarantee-copy p {
+    margin: 0;
+    font-size: 0.9rem;
+    line-height: 1.65;
+    color: #64748b;
+  }
+
+  :global(.connect-wallet-cta) {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.9rem;
+    margin-top: 1.75rem;
+  }
+
+  :global(.connect-wallet-cta__action) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+    min-height: 3rem;
+    padding: 0.85rem 1.35rem;
+    border-radius: 999px;
+    font-size: 0.95rem;
+    font-weight: 700;
+    text-decoration: none;
+    transition:
+      transform 180ms ease,
+      box-shadow 180ms ease,
+      border-color 180ms ease,
+      background 180ms ease,
+      color 180ms ease;
+  }
+
+  :global(.connect-wallet-cta__action:hover) {
+    transform: translateY(-1px);
+  }
+
+  :global(.connect-wallet-cta__action:focus-visible) {
+    outline: 2px solid #8b5cf6;
+    outline-offset: 3px;
+  }
+
+  :global(.connect-wallet-cta__action--primary) {
+    border: 1px solid rgba(16, 25, 63, 0.08);
+    background: linear-gradient(135deg, #10193f, #1e3a8a 68%, #2857b8);
+    box-shadow: 0 16px 30px -18px rgba(30, 58, 138, 0.75);
+    color: #fff;
+    cursor: pointer;
+  }
+
+  :global(.connect-wallet-cta__action--primary:disabled) {
+    opacity: 0.8;
+    cursor: wait;
+    transform: none;
+  }
+
+  :global(.connect-wallet-cta__action--secondary) {
+    border: 1px solid rgba(40, 87, 184, 0.14);
+    background: rgba(255, 255, 255, 0.72);
+    color: #2857b8;
+    box-shadow: 0 10px 24px -18px rgba(15, 23, 42, 0.35);
+  }
+
+  :global(.connect-wallet-cta__icon) {
+    display: inline-flex;
+    flex-shrink: 0;
+  }
+
+  :global(.connect-wallet-cta__action--secondary:hover) {
+    border-color: rgba(124, 58, 237, 0.24);
+    color: #6d28d9;
+  }
+
+  @media (max-width: 767px) {
+    .our-promise {
+      padding-inline: 1rem;
+    }
+
+    .our-promise__badge {
+      width: 100%;
+      justify-content: flex-start;
+    }
+
+    .our-promise__verified-badge {
+      position: static;
+      margin-bottom: 1rem;
+      width: fit-content;
+    }
+
+    .our-promise__card-shell {
+      padding-top: 0;
+    }
+
+    :global(.connect-wallet-cta__action) {
+      width: 100%;
+    }
+  }
+
+  @keyframes eyebrowReveal {
+    from {
+      opacity: 0;
+      transform: translateY(12px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes eyebrowLine {
+    from {
+      transform: scaleX(0.15);
+      opacity: 0.35;
+    }
+    to {
+      transform: scaleX(1);
+      opacity: 1;
+    }
+  }
+
+  @keyframes pulseDot {
+    0% {
+      box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.5);
+    }
+    70% {
+      box-shadow: 0 0 0 10px rgba(34, 197, 94, 0);
+    }
+    100% {
+      box-shadow: 0 0 0 0 rgba(34, 197, 94, 0);
+    }
+  }
 </style>


### PR DESCRIPTION
## Summary

Redesign the `OurPromise` section to match the richer Astro landing page aesthetic.

## Changes

- add a subtle section gradient with a faint grid overlay
- restyle the guarantees card with a glassmorphism treatment, softer borders, and deeper shadow
- replace raw emoji in guarantee rows and mini-badges with Lucide icons
- add colored icon circles for each guarantee item
- animate the `OUR PROMISE` eyebrow with a CSS reveal effect
- upgrade the verified badge with a pulsing green live-status dot
- restyle the `ConnectWalletCTA` island so both actions render as polished CTA buttons
- extend the Astro icon allowlist to include `users`

## Verification

- `npm ci`
- `npm run build` currently fails due to an unrelated existing import issue:
  `src/components/HowItWorks/Stepper.jsx` cannot resolve `motion`

## Notes

- no new dependencies were added
- styling remains component-local, with targeted global selectors only for the hydrated CTA island

resolves #207 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new icon option to support updated visual elements across the site.
  * Improved the wallet connection CTA to handle Freighter-based access flow and reflect connection state in the primary button.

* **UI Improvements**
  * Redesigned the “Our Promise” section into a componentized, icon- and tone-driven layout with updated badges, gradients, and animations.
  * Enhanced responsive styling and spacing for the section and the wallet CTA on smaller screens.
  * Improved error-state handling so the CTA reliably returns to an idle/locked presentation on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->