### PR TITLE
fix(TrustBadges): replace emojis with Lucide icon pills (closes c214)

### DIFF
--- a/ST-Landing-Page(new one)/astro.config.mjs
+++ b/ST-Landing-Page(new one)/astro.config.mjs
@@ -25,6 +25,7 @@ export default defineConfig({
           "wallet",
           "shield-check",
           "coins",
+          "eye",
         ],
       },
     }),

--- a/ST-Landing-Page(new one)/src/components/Hero/TrustBadges.astro
+++ b/ST-Landing-Page(new one)/src/components/Hero/TrustBadges.astro
@@ -1,27 +1,133 @@
 ---
+import { Icon } from "astro-icon/components";
+
 const badges = [
-  { label: "Secure Escrow", icon: "🛡️" },
-  { label: "Decentralized", icon: "🌐" },
-  { label: "Transparent", icon: "👁️" },
-  { label: "Lightning Fast", icon: "⚡" },
-];
+  { label: "Secure Escrow", icon: "lucide:shield-check", tone: "green" },
+  { label: "Decentralized", icon: "lucide:globe", tone: "blue" },
+  { label: "Transparent", icon: "lucide:eye", tone: "purple" },
+  { label: "Lightning Fast", icon: "lucide:zap", tone: "amber" },
+] as const;
 ---
 
-<div class="trust-badges">
+<div class="trust-badges" role="list" aria-label="Trust indicators">
   {badges.map((b) => (
-    <span class="badge-pill">
-      <span class="icon">{b.icon}</span>
-      {b.label}
+    <span class={`badge-pill badge-pill--${b.tone}`} role="listitem">
+      <span class="badge-pill__icon" aria-hidden="true">
+        <Icon name={b.icon} width="16" height="16" />
+      </span>
+      <span class="badge-pill__label">{b.label}</span>
     </span>
   ))}
 </div>
 
 <style>
-  .trust-badges { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-top: 2rem; }
+  .trust-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 2rem;
+  }
+
   .badge-pill {
-    display: inline-flex; align-items: center; gap: 0.4rem;
-    padding: 0.4rem 0.9rem; border-radius: 999px;
-    font-size: 0.875rem; font-weight: 500;
-    background: rgba(0,0,0,0.04);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.5rem 1rem;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    background: rgba(255, 255, 255, 0.04);
+    font-size: 0.875rem;
+    font-weight: 600;
+    transition:
+      transform 180ms ease,
+      box-shadow 180ms ease,
+      border-color 180ms ease,
+      background 180ms ease,
+      color 180ms ease;
+  }
+
+  .badge-pill:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 22px -16px rgba(15, 23, 42, 0.45);
+  }
+
+  .badge-pill__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.65rem;
+    height: 1.65rem;
+    border-radius: 999px;
+    flex-shrink: 0;
+  }
+
+  .badge-pill__label {
+    color: inherit;
+  }
+
+  /* Green — Secure Escrow */
+  .badge-pill--green {
+    background: rgba(22, 163, 74, 0.12);
+    border-color: rgba(22, 163, 74, 0.28);
+    color: #15803d;
+  }
+  .badge-pill--green:hover {
+    box-shadow: 0 10px 24px -16px rgba(22, 163, 74, 0.55);
+  }
+  .badge-pill--green .badge-pill__icon {
+    background: rgba(22, 163, 74, 0.2);
+    color: #15803d;
+  }
+
+  /* Blue — Decentralized */
+  .badge-pill--blue {
+    background: rgba(40, 87, 184, 0.12);
+    border-color: rgba(40, 87, 184, 0.28);
+    color: #2857b8;
+  }
+  .badge-pill--blue:hover {
+    box-shadow: 0 10px 24px -16px rgba(40, 87, 184, 0.55);
+  }
+  .badge-pill--blue .badge-pill__icon {
+    background: rgba(40, 87, 184, 0.2);
+    color: #2857b8;
+  }
+
+  /* Purple — Transparent */
+  .badge-pill--purple {
+    background: rgba(124, 58, 237, 0.12);
+    border-color: rgba(124, 58, 237, 0.28);
+    color: #7c3aed;
+  }
+  .badge-pill--purple:hover {
+    box-shadow: 0 10px 24px -16px rgba(124, 58, 237, 0.55);
+  }
+  .badge-pill--purple .badge-pill__icon {
+    background: rgba(124, 58, 237, 0.2);
+    color: #7c3aed;
+  }
+
+  /* Amber — Lightning Fast */
+  .badge-pill--amber {
+    background: rgba(245, 158, 11, 0.14);
+    border-color: rgba(245, 158, 11, 0.32);
+    color: #d97706;
+  }
+  .badge-pill--amber:hover {
+    box-shadow: 0 10px 24px -16px rgba(245, 158, 11, 0.55);
+  }
+  .badge-pill--amber .badge-pill__icon {
+    background: rgba(245, 158, 11, 0.22);
+    color: #d97706;
+  }
+
+  @media (max-width: 480px) {
+    .trust-badges {
+      gap: 0.5rem;
+    }
+    .badge-pill {
+      padding: 0.4rem 0.8rem;
+      font-size: 0.8rem;
+    }
   }
 </style>


### PR DESCRIPTION
Closes #214
- Swap emoji glyphs for astro-icon Lucide icons: shield-check, globe, eye, zap.

- Add translucent, color-bordered badge pills (green/blue/purple/amber) matching the original Next.js TrustBadges.

- Register 'eye' in the bundled lucide include list in astro.config.mjs.

- Improve a11y with role=list/listitem and aria-label.

Refs #214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the trust badges in the hero section to use cleaner icon-based visuals.
  * Added richer badge styling with color themes, improved spacing, and hover effects.
  * Improved mobile presentation for the badge row on smaller screens.

* **Accessibility**
  * Added clearer list semantics and hidden decorative icon labels for better screen reader support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->