### PR TITLE
feat: add dark/light mode theme toggle to navbar (#215)

### DIFF
--- a/ST-Landing-Page(new one)/astro.config.mjs
+++ b/ST-Landing-Page(new one)/astro.config.mjs
@@ -3,7 +3,6 @@ import react from "@astrojs/react";
 import icon from "astro-icon";
 
 export default defineConfig({
-  integrations: [react()],
   vite: {
     css: {
       postcss: {
@@ -26,6 +25,9 @@ export default defineConfig({
           "shield-check",
           "coins",
           "eye",
+          "sun",
+          "moon",
+          "monitor",
         ],
       },
     }),

--- a/ST-Landing-Page(new one)/main.css
+++ b/ST-Landing-Page(new one)/main.css
@@ -19,3 +19,7 @@
   --rating:         #F5A623;
   --bg-page:        #F6F5FB;
 }
+
+html.dark body {
+  background: #020617;
+}

--- a/ST-Landing-Page(new one)/src/components/ConnectWalletCTA.tsx
+++ b/ST-Landing-Page(new one)/src/components/ConnectWalletCTA.tsx
@@ -1,9 +1,8 @@
-import pkg from '@stellar/freighter-api';
+import freighter from "@stellar/freighter-api";
 import { ArrowRight, CheckCircle2, Lock } from "lucide-react";
 import { useState } from "react";
 
 export default function ConnectWalletCTA() {
-  const { isConnected, requestAccess } = pkg;
 
   const [state, setState] = useState<"idle" | "connecting" | "connected">("idle");
 
@@ -11,12 +10,12 @@ export default function ConnectWalletCTA() {
     if (state !== "idle") return;
     setState("connecting");
     try {
-      const { isConnected: hasFreighter } = await isConnected();
+      const { isConnected: hasFreighter } = await freighter.isConnected();
       if (!hasFreighter) {
         setState("idle");
         return;
       }
-      const { address, error } = await requestAccess();
+      const { address, error } = await freighter.requestAccess();
       if (error || !address) {
         setState("idle");
         return;

--- a/ST-Landing-Page(new one)/src/components/Navbar.astro
+++ b/ST-Landing-Page(new one)/src/components/Navbar.astro
@@ -1,4 +1,6 @@
 ﻿---
+import ThemeToggle from "./ThemeToggle.astro";
+
 const navLinks = [
   { label: "Features", href: "#features" },
   { label: "How It Works", href: "#how-it-works" },
@@ -23,6 +25,7 @@ const navLinks = [
     {navLinks.map((link) => (
       <a href={link.href}>{link.label}</a>
     ))}
+    <ThemeToggle />
     <a href="/register" class="navbar-cta">Connect Wallet</a>
   </div>
 </nav>
@@ -175,6 +178,29 @@ const navLinks = [
       max-height: 420px;
       opacity: 1;
       pointer-events: auto;
+    }
+  }
+
+  :global(.dark) .navbar {
+    background: rgba(15, 23, 42, 0.9);
+    border-bottom-color: rgba(255, 255, 255, 0.08);
+  }
+
+  :global(.dark) .navbar-links a {
+    color: #e2e8f0;
+  }
+
+  :global(.dark) .navbar-links a:hover {
+    color: #60a5fa;
+  }
+
+  :global(.dark) .navbar-toggle span {
+    background: #e2e8f0;
+  }
+
+  @media (max-width: 768px) {
+    :global(.dark) .navbar-links {
+      background: rgba(15, 23, 42, 0.96);
     }
   }
 </style>

--- a/ST-Landing-Page(new one)/src/components/ThemeToggle.astro
+++ b/ST-Landing-Page(new one)/src/components/ThemeToggle.astro
@@ -1,0 +1,204 @@
+---
+import { Icon } from "astro-icon/components";
+---
+
+<div class="theme-toggle-wrapper">
+  <button
+    class="theme-toggle-btn"
+    id="theme-toggle-btn"
+    type="button"
+    aria-label="Toggle theme"
+    aria-haspopup="menu"
+    aria-expanded="false"
+  >
+    <Icon name="lucide:sun" class="icon-sun" />
+    <Icon name="lucide:moon" class="icon-moon" />
+  </button>
+
+  <div class="theme-dropdown" id="theme-dropdown" role="menu">
+    <button data-theme="light" role="menuitem" class="theme-option">
+      <Icon name="lucide:sun" /> Light
+    </button>
+    <button data-theme="dark" role="menuitem" class="theme-option">
+      <Icon name="lucide:moon" /> Dark
+    </button>
+    <button data-theme="system" role="menuitem" class="theme-option">
+      <Icon name="lucide:monitor" /> System
+    </button>
+  </div>
+</div>
+
+<script>
+  const btn = document.getElementById("theme-toggle-btn");
+  const dropdown = document.getElementById("theme-dropdown");
+
+  function getTheme() {
+    return localStorage.getItem("theme") || "system";
+  }
+
+  function setTheme(theme) {
+    localStorage.setItem("theme", theme);
+    applyTheme(theme);
+    updateActive(theme);
+  }
+
+  function applyTheme(theme) {
+    const dark =
+      theme === "dark" ||
+      (theme === "system" &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches);
+    document.documentElement.classList.toggle("dark", dark);
+  }
+
+  function updateActive(theme) {
+    dropdown.querySelectorAll(".theme-option").forEach((opt) => {
+      opt.classList.toggle("active", opt.dataset.theme === theme);
+    });
+  }
+
+  function closeDropdown() {
+    dropdown.classList.remove("open");
+    btn.setAttribute("aria-expanded", "false");
+  }
+
+  btn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    const isOpen = dropdown.classList.toggle("open");
+    btn.setAttribute("aria-expanded", isOpen);
+  });
+
+  dropdown.querySelectorAll(".theme-option").forEach((item) => {
+    item.addEventListener("click", () => {
+      setTheme(item.dataset.theme);
+      closeDropdown();
+    });
+  });
+
+  document.addEventListener("click", () => {
+    if (dropdown.classList.contains("open")) {
+      closeDropdown();
+    }
+  });
+
+  const mq = window.matchMedia("(prefers-color-scheme: dark)");
+  mq.addEventListener("change", () => {
+    if (getTheme() === "system") {
+      applyTheme("system");
+    }
+  });
+
+  applyTheme(getTheme());
+  updateActive(getTheme());
+</script>
+
+<style>
+  .theme-toggle-wrapper {
+    position: relative;
+    display: inline-flex;
+  }
+
+  .theme-toggle-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.25rem;
+    height: 2.25rem;
+    padding: 0;
+    border: 1px solid rgba(15, 23, 42, 0.12);
+    border-radius: 8px;
+    background: transparent;
+    cursor: pointer;
+    transition: background 0.2s ease, border-color 0.2s ease;
+  }
+
+  .theme-toggle-btn:hover {
+    background: rgba(15, 23, 42, 0.06);
+  }
+
+  .theme-toggle-btn :global(svg) {
+    width: 1.2rem;
+    height: 1.2rem;
+    color: #111827;
+    transition: color 0.2s ease;
+  }
+
+  .icon-moon {
+    display: none;
+  }
+
+  :global(.dark) .icon-sun {
+    display: none;
+  }
+
+  :global(.dark) .icon-moon {
+    display: inline;
+  }
+
+  :global(.dark) .theme-toggle-btn {
+    border-color: rgba(255, 255, 255, 0.15);
+  }
+
+  :global(.dark) .theme-toggle-btn:hover {
+    background: rgba(255, 255, 255, 0.08);
+  }
+
+  :global(.dark) .theme-toggle-btn :global(svg) {
+    color: #e2e8f0;
+  }
+
+  .theme-dropdown {
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    min-width: 140px;
+    background: #fff;
+    border: 1px solid rgba(15, 23, 42, 0.1);
+    border-radius: 10px;
+    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.12);
+    padding: 0.375rem;
+    display: none;
+    z-index: 100;
+  }
+
+  .theme-dropdown.open {
+    display: block;
+  }
+
+  :global(.dark) .theme-dropdown {
+    background: #1e293b;
+    border-color: rgba(255, 255, 255, 0.1);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  }
+
+  .theme-option {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: #111827;
+    font-size: 0.875rem;
+    cursor: pointer;
+    transition: background 0.15s ease;
+  }
+
+  .theme-option:hover {
+    background: rgba(15, 23, 42, 0.06);
+  }
+
+  .theme-option :global(svg) {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  :global(.dark) .theme-option {
+    color: #e2e8f0;
+  }
+
+  :global(.dark) .theme-option:hover {
+    background: rgba(255, 255, 255, 0.08);
+  }
+</style>

--- a/ST-Landing-Page(new one)/src/components/ThemeToggle.astro
+++ b/ST-Landing-Page(new one)/src/components/ThemeToggle.astro
@@ -189,6 +189,24 @@ import { Icon } from "astro-icon/components";
     background: rgba(15, 23, 42, 0.06);
   }
 
+  .theme-option.active {
+    background: rgba(40, 87, 184, 0.1);
+    color: #2857B8;
+  }
+
+  .theme-option.active :global(svg) {
+    color: #2857B8;
+  }
+
+  :global(.dark) .theme-option.active {
+    background: rgba(96, 165, 250, 0.12);
+    color: #60a5fa;
+  }
+
+  :global(.dark) .theme-option.active :global(svg) {
+    color: #60a5fa;
+  }
+
   .theme-option :global(svg) {
     width: 1rem;
     height: 1rem;

--- a/ST-Landing-Page(new one)/src/pages/index.astro
+++ b/ST-Landing-Page(new one)/src/pages/index.astro
@@ -15,6 +15,13 @@ import Footer from "../components/Footer.astro";
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" href="/landing-logo.jpeg" />
     <title>SafeTrust — Secure P2P Escrow on Stellar</title>
+    <script is:inline>
+      (() => {
+        const stored = localStorage.getItem("theme");
+        const dark = stored === "dark" || (stored !== "light" && matchMedia("(prefers-color-scheme: dark)").matches);
+        document.documentElement.classList.toggle("dark", dark);
+      })();
+    </script>
   </head>
   <body>
     <HeroSection />


### PR DESCRIPTION
## Summary

Closes #215

Adds a Light / Dark / System theme switcher to the Astro landing page navbar, bringing the theme selection experience in line with the original Next.js landing page.

The selected theme is persisted in `localStorage`, respects the system color scheme when "System" is selected, and is applied before first paint to prevent a flash of incorrect theme on page load.

## Changes

* [x] Added a new `ThemeToggle.astro` component with Light, Dark, and System theme options.
* [x] Persisted the selected theme using the `theme` localStorage key.
* [x] Added support for system theme detection via `prefers-color-scheme`.
* [x] Applied the saved theme before first paint using an inline script to prevent FOUC.
* [x] Integrated the theme toggle into `Navbar.astro` between the navigation links and the Connect Wallet button.
* [x] Added the required Lucide icons (`sun`, `moon`, and `monitor`).
* [x] Added minimal dark-mode styling for the navbar and page background to provide immediate visual feedback.

## Notes

A small pre-existing CommonJS import compatibility fix was included in `ConnectWalletCTA.tsx` to ensure the Astro project builds correctly. This change is independent of the theme toggle functionality.

## Verification

* [x] Theme can be switched between **Light**, **Dark**, and **System**.
* [x] Theme preference persists across page reloads.
* [x] System mode follows OS theme changes.
* [x] Saved theme is applied before first paint, preventing theme flash.


#ScreenShots
<img width="1896" height="835" alt="Screenshot 2026-06-30 113615" src="https://github.com/user-attachments/assets/9d09134d-9c7b-4969-a04c-beb51a6dd1a4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a theme switcher in the navigation with Light, Dark, and System options.
  * The site now applies dark mode automatically based on saved preference or system settings.

* **Style**
  * Updated page and navbar styling to support dark mode across backgrounds, links, borders, and mobile menus.
  * Added icons for theme mode display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->