### PR TITLE
Fix FinalCTA headline copy, light/dark background, and contrast issues (#237)

### DIFF
--- a/landing-SafeTrust/src/components/FinalCTA.astro
+++ b/landing-SafeTrust/src/components/FinalCTA.astro
@@ -14,7 +14,7 @@
 
     <h2 class="cta-heading">
       Ready to secure your<br/>
-      <span class="italic text-purple-accent">with transactions?</span>
+      <span class="italic text-purple-accent">transactions?</span>
     </h2>
 
     <p class="cta-description">
@@ -65,11 +65,32 @@
     }
   }
 
+  .final-cta-section {
+    border-radius: 1.5rem;
+    margin: 0 1.5rem;
+  }
+  @media (min-width: 768px) {
+    .final-cta-section {
+      margin: 0 2rem;
+    }
+  }
+
+  :global(html.dark) .final-cta-section {
+    border-radius: 0;
+    margin: 0;
+    box-shadow: 0 0 80px rgba(124, 58, 237, 0.2);
+  }
+
   .cta-bg-gradient {
     position: absolute;
     inset: 0;
     background: linear-gradient(to bottom right, #111827, #1e3a8a, #000000);
     z-index: 1;
+    border-radius: inherit;
+  }
+
+  :global(html.dark) .cta-bg-gradient {
+    opacity: 0.85;
   }
 
   .cta-bg-overlay {
@@ -77,6 +98,7 @@
     inset: 0;
     background: linear-gradient(to top, rgba(0,0,0,0.5), transparent);
     z-index: 2;
+    border-radius: inherit;
   }
 
   .cta-content {
@@ -174,7 +196,7 @@
   .btn-secondary {
     background: transparent;
     color: white;
-    border: 2px solid rgba(255, 255, 255, 0.2);
+    border: 2px solid rgba(255, 255, 255, 0.5);
   }
   .btn-secondary:hover {
     border-color: rgba(59, 130, 246, 0.5);
@@ -189,7 +211,7 @@
     justify-content: center;
     gap: 1.5rem;
     margin-top: 3rem;
-    color: #9ca3af;
+    color: rgba(255, 255, 255, 0.75);
     font-size: 0.875rem;
   }
 


### PR DESCRIPTION
Closes #237
Changes:

Copy fix ; Headline read "Ready to secure your / with transactions?" (grammatically broken). Fixed to "Ready to secure your / transactions?" with the italic purple accent preserved on the second line.
Light/dark background fix; Section previously used a hardcoded dark gradient that ignored the site's CSS variable/theme system, causing it to look identical in both modes and bleed edge-to-edge into the footer in light mode.
Light mode: added border-radius: 1.5rem and horizontal margin so the dark gradient section now floats as a rounded card above the footer.
Dark mode: reduced gradient opacity to 0.85 and added a box-shadow: 0 0 80px rgba(124, 58, 237, 0.2) purple glow so it stands out against the dark page background.
Color corrections:
Stats row text (10,000+ Active Users, etc.) updated to rgba(255,255,255,0.75) for consistent readability.
"Read the Docs" button border opacity increased from 0.2 to 0.5 (was nearly invisible).
Verified visually in both light and dark mode via local dev server (npm run dev), see screenshots below.
<img width="2965" height="1407" alt="Screenshot 2026-07-23 102408" src="https://github.com/user-attachments/assets/20e8f607-14f8-459c-b3ac-74bda0dfc3cd" />
 
<img width="2977" height="1372" alt="Screenshot 2026-07-23 102145" src="https://github.com/user-attachments/assets/266c80de-5f21-4332-b13c-4076561c19f1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the final call-to-action section’s layout, spacing, rounded corners, gradients, and dark-mode appearance.
  * Improved button border visibility and adjusted statistics text contrast.
* **Content**
  * Shortened the call-to-action heading for a more concise message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->