### PR TITLE
Fix Hero and EscrowCard dark mode overrides + broken CSS block (#239)

### DIFF
--- a/landing-SafeTrust/src/components/Hero/HeroSection.astro
+++ b/landing-SafeTrust/src/components/Hero/HeroSection.astro
@@ -51,12 +51,20 @@ import EscrowCard from "./EscrowCard.tsx";
     position: absolute; inset: 0;
     background: radial-gradient(circle at 70% 30%, rgba(40,87,184,0.15), transparent 60%);
   }
+  :global(.dark) .gradient-mesh {
+    background:
+      radial-gradient(ellipse 80% 60% at 70% 10%, rgba(40, 87, 184, 0.25) 0%, transparent 70%),
+      radial-gradient(ellipse 60% 50% at 10% 80%, rgba(124, 58, 237, 0.20) 0%, transparent 65%),
+      radial-gradient(ellipse 50% 40% at 90% 85%, rgba(6, 182, 212, 0.12) 0%, transparent 60%),
+      linear-gradient(160deg, #060d1f 0%, #0a1128 50%, #060d1f 100%);
+  }
   .grid-pattern {
     position: absolute; inset: 0;
     background-image: linear-gradient(var(--hero-grid) 1px, transparent 1px),
                       linear-gradient(90deg, var(--hero-grid) 1px, transparent 1px);
     background-size: 40px 40px;
   }
+  :global(.dark) .grid-pattern { display: none; }
   .hero-container {
     display: grid;
     grid-template-columns: 1fr;

--- a/landing-SafeTrust/src/styles/escrow-card.css
+++ b/landing-SafeTrust/src/styles/escrow-card.css
@@ -132,15 +132,23 @@
 .icon.idle {
   background: rgba(107, 114, 128, 0.1);
   color: #6b7280;
-  .escrow-card {
-    background: #111827;
-    border-color: #1f2937;
-    color: #f9fafb;
-  }
-  .progress-track {
-    background: #1f2937;
-  }
-  .footer {
-    border-top-color: #1f2937;
-  }
 }
+
+.footer {
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e5e7eb;
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
+.dark .escrow-card {
+  background: #1e293b;
+  border-color: #334155;
+  color: #f1f5f9;
+}
+
+.dark .label { color: #94a3b8; }
+.dark .progress-track { background: #334155; }
+.dark .timeline-label { color: #64748b; }
+.dark .footer { border-top-color: #334155; color: #64748b; }


### PR DESCRIPTION
Closes #239

**Changes:**

**HeroSection.astro** — added `:global(.dark)` overrides for the hero background, matching the layered gradient spec:
- `.gradient-mesh`: layered radial gradients (blue/purple/cyan) over a dark navy linear gradient base
- `.grid-pattern`: hidden in dark mode (`display: none`)

**escrow-card.css** — this file had a genuine bug: a broken, incorrectly-nested block sitting inside `.icon.idle` with no `@media` or class wrapper, so it was dead code that never applied (this was the "partial media query" mentioned in the issue). Replaced it with:
- `.dark .escrow-card`, `.dark .label`, `.dark .progress-track`, `.dark .timeline-label`, `.dark .footer` — using the exact hex values from the issue spec.

**Important note for reviewer:** the issue's Expected Behavior snippet showed `:global(.dark)` for `escrow-card.css`, but `:global()` is an Astro-scoped-`<style>`-only construct — it's not valid in a plain external `.css` file like this one (it would silently never match). I used plain `.dark` instead, which correctly targets the `html.dark` ancestor and matches the convention already used in `theme.css`.

**Also added:** a base (light-mode) `.footer` style for the EscrowCard — it had no styling at all before (no border/spacing), which is why the dark-mode `border-top-color` override had nothing to override against. Not explicitly specced, so flagging as a judgment call.

**Testing:** Verified visually in both light and dark mode via local dev server (`npm run dev`);
<img width="2760" height="1467" alt="Screenshot 2026-07-23 123225" src="https://github.com/user-attachments/assets/97991c73-2efb-47ef-8681-e3c3b4fd60c2" />
<img width="2765" height="1447" alt="Screenshot 2026-07-23 123346" src="https://github.com/user-attachments/assets/6e6677de-1e55-419d-95a5-2dd1f93cc39d" />
 see screenshots below.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark-mode styling for the hero section with a dedicated gradient treatment.
  * Hidden the grid background in dark mode for a cleaner appearance.
  * Enhanced dark-mode escrow card readability, including labels, timeline text, footer styling, borders, and contrast.
  * Added consistent default spacing, typography, and border styling to escrow card footers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->