### PR TITLE
feat(landing-SafeTrust): hero-section-gradient-background-and-escrowcard-

### DIFF
--- a/landing-SafeTrust/src/components/Hero/HeroSection.astro
+++ b/landing-SafeTrust/src/components/Hero/HeroSection.astro
@@ -119,6 +119,18 @@ import EscrowCard from "./EscrowCard.tsx";
     0%, 100% { transform: translate(-50%, 0); }
     50% { transform: translate(-50%, 6px); }
   }
+
+  :global(.dark) .gradient-mesh {
+    background:
+      radial-gradient(ellipse 80% 60% at 70% 10%, rgba(40, 87, 184, 0.25) 0%, transparent 70%),
+      radial-gradient(ellipse 60% 50% at 10% 80%, rgba(124, 58, 237, 0.20) 0%, transparent 65%),
+      radial-gradient(ellipse 50% 40% at 90% 85%, rgba(6, 182, 212, 0.12) 0%, transparent 60%),
+      linear-gradient(160deg, #060d1f 0%, #0a1128 50%, #060d1f 100%);
+  }
+
+  :global(.dark) .grid-pattern {
+    display: none;
+  }
 </style>
 
 <script>

--- a/landing-SafeTrust/src/styles/escrow-card.css
+++ b/landing-SafeTrust/src/styles/escrow-card.css
@@ -132,15 +132,35 @@
 .icon.idle {
   background: rgba(107, 114, 128, 0.1);
   color: #6b7280;
-  .escrow-card {
-    background: #111827;
-    border-color: #1f2937;
-    color: #f9fafb;
-  }
-  .progress-track {
-    background: #1f2937;
-  }
-  .footer {
-    border-top-color: #1f2937;
-  }
+}
+
+.footer {
+  margin-top: 1.25rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid #f3f4f6;
+  font-size: 0.75rem;
+  color: #9ca3af;
+}
+
+.dark .escrow-card {
+  background: #1e293b;
+  border-color: #334155;
+  color: #f1f5f9;
+}
+
+.dark .label {
+  color: #94a3b8;
+}
+
+.dark .progress-track {
+  background: #334155;
+}
+
+.dark .timeline-label {
+  color: #64748b;
+}
+
+.dark .footer {
+  border-top-color: #334155;
+  color: #64748b;
 }


### PR DESCRIPTION
Closes #239

## Summary
- Hero section gradient background and EscrowCard do not adapt to dark mode

## Test plan
- [ ] Relevant tests pass locally
- [ ] Manual verification on affected UI or API paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark mode styling for the hero section with a darker gradient and hidden grid pattern.
  * Enhanced dark mode appearance for escrow cards, progress indicators, labels, timelines, and footer content.
  * Added consistent footer spacing, borders, typography, and text colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->