### PR TITLE
fix: dark mode for OurPromise and SecuritySection sections

### DIFF
--- a/landing-SafeTrust/src/components/OurPromise.astro
+++ b/landing-SafeTrust/src/components/OurPromise.astro
@@ -571,7 +571,7 @@ const miniBadges = [
   }
 
   :global(.dark) .our-promise__card-eyebrow {
-    color: #475569;
+    color: #94a3b8;
   }
 
   :global(.dark) .our-promise__guarantee {

--- a/landing-SafeTrust/src/components/OurPromise.astro
+++ b/landing-SafeTrust/src/components/OurPromise.astro
@@ -523,4 +523,84 @@ const miniBadges = [
     70% { box-shadow: 0 0 0 10px rgba(34, 197, 94, 0); }
     100% { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0); }
   }
+
+  /* Dark mode — keep glassmorphism without near-white surfaces */
+  :global(.dark) .our-promise {
+    background: linear-gradient(135deg, rgba(40, 87, 184, 0.08), rgba(124, 58, 237, 0.08));
+  }
+
+  :global(.dark) .our-promise::before {
+    background-image:
+      linear-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
+  }
+
+  :global(.dark) .our-promise__glow--left {
+    background: rgba(96, 165, 250, 0.18);
+    opacity: 0.7;
+  }
+
+  :global(.dark) .our-promise__glow--right {
+    background: rgba(167, 139, 250, 0.16);
+    opacity: 0.7;
+  }
+
+  :global(.dark) .our-promise__headline {
+    color: #f1f5f9;
+  }
+
+  :global(.dark) .our-promise__description {
+    color: #94a3b8;
+  }
+
+  :global(.dark) .our-promise__badge {
+    background: rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 255, 255, 0.1);
+    color: #e2e8f0;
+    box-shadow: 0 10px 24px -18px rgba(0, 0, 0, 0.55);
+  }
+
+  :global(.dark) .our-promise__card {
+    background: linear-gradient(180deg, rgba(30, 41, 59, 0.9), rgba(15, 23, 42, 0.85));
+    border-color: rgba(255, 255, 255, 0.08);
+    box-shadow: 0 20px 40px -12px rgba(0, 0, 0, 0.4);
+  }
+
+  :global(.dark) .our-promise__card::after {
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.06), transparent 42%);
+  }
+
+  :global(.dark) .our-promise__card-eyebrow {
+    color: #475569;
+  }
+
+  :global(.dark) .our-promise__guarantee {
+    border-top-color: rgba(255, 255, 255, 0.07);
+  }
+
+  :global(.dark) .our-promise__guarantee-copy strong {
+    color: #f1f5f9;
+  }
+
+  :global(.dark) .our-promise__guarantee-copy p {
+    color: #94a3b8;
+  }
+
+  :global(.dark) .our-promise__tag {
+    background: rgba(167, 139, 250, 0.14);
+    border-color: rgba(167, 139, 250, 0.28);
+    color: #c4b5fd;
+  }
+
+  :global(.dark) .connect-wallet-cta__action--secondary {
+    background: rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 255, 255, 0.12);
+    color: #93c5fd;
+    box-shadow: none;
+  }
+
+  :global(.dark) .connect-wallet-cta__action--secondary:hover {
+    border-color: rgba(167, 139, 250, 0.4);
+    color: #c4b5fd;
+  }
 </style>

--- a/landing-SafeTrust/src/styles/security.css
+++ b/landing-SafeTrust/src/styles/security.css
@@ -260,7 +260,7 @@ html.dark .security-dotted-divider {
 }
 
 html.dark .score-label {
-  color: #64748b;
+  color: #94a3b8;
 }
 
 html.dark .score-value.color-green {
@@ -272,7 +272,7 @@ html.dark .score-value.color-blue {
 }
 
 html.dark .certs-label {
-  color: #64748b;
+  color: #94a3b8;
 }
 
 html.dark .security-icon-badge.theme-green {

--- a/landing-SafeTrust/src/styles/security.css
+++ b/landing-SafeTrust/src/styles/security.css
@@ -224,3 +224,64 @@
     margin-bottom: 1.5rem;
   }
 }
+
+/* ============================================================
+   Dark mode
+   ============================================================ */
+
+html.dark .security-title {
+  color: #f1f5f9;
+}
+
+html.dark .security-subtitle {
+  color: #94a3b8;
+}
+
+html.dark .security-card {
+  background: rgba(30, 41, 59, 0.8);
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 4px 20px -2px rgba(0, 0, 0, 0.35), 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+html.dark .security-card:hover {
+  box-shadow: 0 16px 36px -8px rgba(0, 0, 0, 0.45), 0 1px 3px rgba(0, 0, 0, 0.25);
+}
+
+html.dark .security-card-title {
+  color: #f1f5f9;
+}
+
+html.dark .security-card-desc {
+  color: #94a3b8;
+}
+
+html.dark .security-dotted-divider {
+  border-top-color: rgba(255, 255, 255, 0.12);
+}
+
+html.dark .score-label {
+  color: #64748b;
+}
+
+html.dark .score-value.color-green {
+  color: #4ade80;
+}
+
+html.dark .score-value.color-blue {
+  color: #60a5fa;
+}
+
+html.dark .certs-label {
+  color: #64748b;
+}
+
+html.dark .security-icon-badge.theme-green {
+  background-color: #12311e;
+  color: #4ade80;
+}
+
+html.dark .security-icon-badge.theme-blue,
+html.dark .security-icon-badge.theme-navy {
+  background-color: #162338;
+  color: #93c5fd;
+}


### PR DESCRIPTION
## Summary
Fix dark-mode contrast inversions in the Our Promise and Security Features sections.

Closes #240

## Changes
- **`src/components/OurPromise.astro`** — added `:global(.dark)` overrides:
  - `.our-promise__card` → dark gradient surface instead of near-white glassmorphism
  - `.our-promise__badge` / `.our-promise__tag` → low-alpha dark pills
  - `.our-promise__guarantee-copy strong|p` → readable slate text
  - glow orbs / grid overlay / CTA secondary adjusted for dark
- **`src/styles/security.css`** — added `html.dark` rules:
  - cards → `rgba(30, 41, 59, 0.8)` surface, proper border/shadow
  - headings/subtitle/score values/cert labels → readable dark-mode colors
  - badge tints adjusted for contrast

## Verification
- [x] `npm run build` succeeds (Astro 5)
- [x] dark-mode classes match existing `:global(.dark)` pattern used in Navbar.astro / ThemeToggle.astro
- [x] no light-mode regression (scoped overrides only)

## Test plan
1. `npm install && npm run dev`
2. Toggle dark mode
3. Scroll to "Our Promise" — card surface dark, text readable
4. Scroll to "SafeTrust Security Features" — cards dark, scores readable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark mode styling for the “Our Promise” and security sections.
  * Updated backgrounds, gradients, glow effects, borders, shadows, and typography for better contrast and readability.
  * Refined security cards, scores, certifications, badges, and action controls to preserve the glassmorphism design in dark mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->