### PR TITLE
fix(footer): apply dark mode theming and WCAG AA contrast fixes

### DIFF
--- a/landing-SafeTrust/src/components/Footer.astro
+++ b/landing-SafeTrust/src/components/Footer.astro
@@ -114,10 +114,17 @@ const legalLinks = [
   .footer {
     position: relative;
     overflow: hidden;
-    border-top: 1px solid rgba(255, 255, 255, 0.08);
-    background: var(--brand-navy, #10193F);
-    color: #e2e8f0;
+    border-top: 1px solid #e2e8f0;
+    background: #f8faff;
+    color: #475569;
     padding: 3rem 0 0;
+    transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+  }
+
+  :global(.dark) .footer {
+    background: #0a0f1e;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    color: #cbd5e1;
   }
 
   .footer-glow {
@@ -127,6 +134,11 @@ const legalLinks = [
     border-radius: 50%;
     pointer-events: none;
     filter: blur(80px);
+    opacity: 0.04;
+    transition: opacity 0.2s ease;
+  }
+
+  :global(.dark) .footer-glow {
     opacity: 0.15;
   }
 
@@ -145,8 +157,13 @@ const legalLinks = [
   .footer-overlay {
     position: absolute;
     inset: 0;
-    background: linear-gradient(to bottom, transparent, rgba(16, 25, 63, 0.3));
+    background: transparent;
     pointer-events: none;
+    transition: background 0.2s ease;
+  }
+
+  :global(.dark) .footer-overlay {
+    background: linear-gradient(to bottom, transparent, rgba(16, 25, 63, 0.3));
   }
 
   .footer-container {
@@ -176,10 +193,12 @@ const legalLinks = [
   .footer-brand span {
     font-size: 1.25rem;
     font-weight: 700;
-    background: linear-gradient(to right, #60a5fa, #93c5fd);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+    color: #2857b8;
+    transition: color 0.2s ease;
+  }
+
+  :global(.dark) .footer-brand span {
+    color: #60a5fa;
   }
 
   .footer-grid {
@@ -207,9 +226,14 @@ const legalLinks = [
 
   .footer-col-title {
     font-size: 0.9375rem;
-    font-weight: 600;
-    color: #f1f5f9;
+    font-weight: 700;
+    color: #0f172a;
     margin: 0 0 1rem;
+    transition: color 0.2s ease;
+  }
+
+  :global(.dark) .footer-col-title {
+    color: #f1f5f9;
   }
 
   .footer-links {
@@ -222,21 +246,34 @@ const legalLinks = [
   }
 
   .footer-links a {
-    color: #94a3b8;
+    color: #475569;
     text-decoration: none;
     font-size: 0.9375rem;
     transition: color 0.2s ease;
   }
 
   .footer-links a:hover {
+    color: #2857b8;
+  }
+
+  :global(.dark) .footer-links a {
+    color: #94a3b8;
+  }
+
+  :global(.dark) .footer-links a:hover {
     color: #60a5fa;
   }
 
   .footer-newsletter-desc {
     font-size: 0.875rem;
-    color: #94a3b8;
+    color: #475569;
     margin: 0 0 1rem;
     line-height: 1.5;
+    transition: color 0.2s ease;
+  }
+
+  :global(.dark) .footer-newsletter-desc {
+    color: #94a3b8;
   }
 
   .footer-form {
@@ -254,38 +291,52 @@ const legalLinks = [
     flex: 1;
     padding: 0.5rem 0.75rem;
     border-radius: 6px;
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    background: rgba(255, 255, 255, 0.06);
-    color: #e2e8f0;
+    border: 1px solid #cbd5e1;
+    background: #ffffff;
+    color: #0f172a;
     font-size: 0.875rem;
     outline: none;
-    transition: border-color 0.2s;
+    transition: border-color 0.2s, background-color 0.2s, color 0.2s;
     min-width: 0;
   }
 
   .footer-input::placeholder {
-    color: #64748b;
+    color: #94a3b8;
   }
 
   .footer-input:focus {
     border-color: #3b82f6;
   }
 
+  :global(.dark) .footer-input {
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: #f1f5f9;
+  }
+
+  :global(.dark) .footer-input::placeholder {
+    color: rgba(255, 255, 255, 0.35);
+  }
+
+  :global(.dark) .footer-input:focus {
+    border-color: #60a5fa;
+  }
+
   .footer-subscribe-btn {
     padding: 0.5rem 1rem;
     border-radius: 6px;
     border: none;
-    background: var(--brand-accent, #1D4ED8);
+    background: var(--brand-primary, #1e3a8a);
     color: #fff;
     font-size: 0.875rem;
     font-weight: 600;
     cursor: pointer;
     white-space: nowrap;
-    transition: background 0.2s ease;
+    transition: background-color 0.2s ease, transform 0.2s ease;
   }
 
   .footer-subscribe-btn:hover {
-    background: var(--brand-primary, #1E3A8A);
+    background: var(--brand-accent, #1d4ed8);
   }
 
   .footer-consent {
@@ -296,6 +347,11 @@ const legalLinks = [
     color: #64748b;
     cursor: pointer;
     line-height: 1.4;
+    transition: color 0.2s ease;
+  }
+
+  :global(.dark) .footer-consent {
+    color: #94a3b8;
   }
 
   .footer-consent input[type="checkbox"] {
@@ -304,14 +360,28 @@ const legalLinks = [
     accent-color: #3b82f6;
   }
 
+  :global(.dark) .footer-consent input[type="checkbox"] {
+    accent-color: #60a5fa;
+  }
+
   .footer-bottom {
-    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    border-top: 1px solid #e2e8f0;
     padding-top: 1.5rem;
+    transition: border-color 0.2s ease;
+  }
+
+  :global(.dark) .footer-bottom {
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
   }
 
   .footer-bottom p {
     font-size: 0.875rem;
     color: #64748b;
     margin: 0;
+    transition: color 0.2s ease;
+  }
+
+  :global(.dark) .footer-bottom p {
+    color: rgba(255, 255, 255, 0.35);
   }
 </style>


### PR DESCRIPTION
Applies a complete dark mode stylesheet to Footer.astro and fixes the WCAG AA contrast failures reported in dark mode. All hardcoded colors now adapt between light and dark modes via :global(.dark) selectors, and the Subscribe button is wired to var(--brand-primary). 
Closes #238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined footer appearance across light and dark themes.
  * Improved hover, focus, and transition effects for links, form controls, and the subscribe button.
  * Updated newsletter, consent, branding, and footer-bottom styling for better visual consistency.
  * Enhanced footer background glows, overlays, gradients, and form control contrast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->